### PR TITLE
Make the RSS reader smart about encodings

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -9,7 +9,7 @@ import (
 	"time"
 	
 	"code.google.com/p/go-charset/charset"
-	import _ "code.google.com/p/go-charset/data"
+	_ "code.google.com/p/go-charset/data"
 )
 
 type Channel struct {


### PR DESCRIPTION
This change allows your tiny RSS reader to accept a pretty much arbitrary encoding, at the cost of importing an external dependency - the "charset" package. ioutil is not needed any longer because of different semantics of xml.NewDecoder constructor and so is not imported.
