### PR TITLE
Use an interface, not an implementation

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -12,6 +12,10 @@ import (
 	_ "code.google.com/p/go-charset/data"
 )
 
+type Fetcher interface {
+	Get(url string) (resp *http.Response, err error)
+}
+
 type Channel struct {
 	Title         string `xml:"title"`
 	Link          string `xml:"link"`
@@ -76,7 +80,7 @@ func Read(url string) (*Channel, error) {
 	return ReadWithClient(url, http.DefaultClient)
 }
 
-func ReadWithClient(url string, client *http.Client) (*Channel, error) {
+func ReadWithClient(url string, client Fetcher) (*Channel, error) {
 	response, err := client.Get(url)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I just realised that my change was sort of lame since it enforced the usage of a particular implementation whereas what you really care is whether that implementation does what you expect it to do. My apologies, that was dumb and this commit fixes this obvious mistake.

This should also mean this package will become nicely testable since you can now use DI to create a Fetcher slurping XML feeds saved into a local test directory.
