### PR TITLE
Updated Item struct to allow Array of ItemEnclosure

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -35,15 +35,15 @@ type ItemEnclosure struct {
 }
 
 type Item struct {
-	Title       string        `xml:"title"`
-	Link        string        `xml:"link"`
-	Comments    string        `xml:"comments"`
-	PubDate     Date          `xml:"pubDate"`
-	GUID        string        `xml:"guid"`
-	Category    []string      `xml:"category"`
-	Enclosure   ItemEnclosure `xml:"enclosure"`
-	Description string        `xml:"description"`
-	Content     string        `xml:"content"`
+	Title       string          `xml:"title"`
+	Link        string          `xml:"link"`
+	Comments    string          `xml:"comments"`
+	PubDate     Date            `xml:"pubDate"`
+	GUID        string          `xml:"guid"`
+	Category    []string        `xml:"category"`
+	Enclosure   []ItemEnclosure `xml:"enclosure"`
+	Description string          `xml:"description"`
+	Content     string          `xml:"content"`
 }
 
 type Date string

--- a/testdata/podcast.rss
+++ b/testdata/podcast.rss
@@ -1,0 +1,601 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+
+<channel>
+
+<title>W&amp;W Mainstage Podcast</title>
+<link>http://podcast.wandwmusic.nl</link>
+<itunes:subtitle>The official podcast of W&amp;W - trance duo Willem van Hanegem &amp; Ward van der Harst</itunes:subtitle>
+<itunes:summary>W&amp;W’s weekly Mainstage show exports their diverse sound around the world. The Mainstage Podcast is all about showcasing the freshest new music without any boundaries!</itunes:summary>
+<description>W&amp;W’s weekly Mainstage show exports their diverse sound around the world. The Mainstage Podcast is all about showcasing the freshest new music without any boundaries!</description>
+<language>en-gb</language>
+<copyright>W&amp;W Music</copyright>
+<itunes:owner>
+   <itunes:name>W&amp;W Music</itunes:name>
+   <itunes:email>info@wandwmusic.com</itunes:email>
+</itunes:owner>
+<managingEditor>info@wandwmusic.com (W&amp;W Music)</managingEditor>
+<itunes:author>W&amp;W Music</itunes:author>
+<image>
+   <url>http://podcast.wandwmusic.nl/audio/rssimage.jpg</url>
+   <title>W&amp;W Mainstage Podcast</title>
+   <link>http://podcast.wandwmusic.nl</link>
+</image>
+<itunes:image href="http://podcast.wandwmusic.nl/audio/itunescover.jpg" />
+<pubDate>Mon, 01 Jun 2015 07:40:48 +0000</pubDate>
+<lastBuildDate>Sat, 30 May 2015 11:11:00 +0000</lastBuildDate>
+<generator>Loudblog</generator>
+
+<itunes:explicit>no</itunes:explicit>
+
+<itunes:category text="Music" />
+<category>Music</category>
+
+
+<item>
+    <pubDate>Sat, 30 May 2015 11:11:00 +0000</pubDate>
+    <title>W&amp;W - Mainstage 259 Podcast</title>
+    <link>http://podcast.wandwmusic.nl/index.php?id=224</link>
+    <guid>http://podcast.wandwmusic.nl/index.php?id=224</guid>
+    <dc:creator>W&amp;W Music</dc:creator>
+    <itunes:author>W&amp;W Music</itunes:author>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:keywords>Music</itunes:keywords>
+    <category>Music</category>
+    <itunes:subtitle>01. Alesso ft. Sirena - Sweet Escape
+02. W&amp;W &amp; Blasterjaxx - Bowser
+03. The Wombats - Give Me A Try (Don Diablo Remix)
+04. Smash of the Week: Tiesto &amp; DallasK - Show Me
+05. Ephwurd &amp; Mauz - Rock The Party
+06. David Solano - Take Me </itunes:subtitle>
+    <itunes:summary>01. Alesso ft. Sirena - Sweet Escape
+02. W&amp;W &amp; Blasterjaxx - Bowser
+03. The Wombats - Give Me A Try (Don Diablo Remix)
+04. Smash of the Week: Tiesto &amp; DallasK - Show Me
+05. Ephwurd &amp; Mauz - Rock The Party
+06. David Solano - Take Me Away
+07. Carl Tricks - Quack
+08. Above &amp; Beyond ft. Zoe Johnston - Peace Of Mind (Myon &amp; Shane 54 Summer Of Love Mix)
+09. Third Party - Alive
+10. Dillon Francis &amp; Dj Snake Get Low (W&amp;W Remix)
+11. Orjan Nilsen - Now We’re Talking
+12. Borgoeus ft. Lights - Zero Gravity
+13. Dyro - Pure Noise
+14. Zedd &amp; Botnek - Bumble Bee
+15. Five Knives - Savages (Tom Swoon Club Mix)
+16. Capa - From Here
+17. MaRlo - Atlantis
+18. W&amp;W - Rave After Rave (Bosiyaw Remix)</itunes:summary>
+
+    <description>&lt;p&gt;01. Alesso ft. Sirena - Sweet Escape&lt;br /&gt;
+02. W&amp;amp;W &amp;amp; Blasterjaxx - Bowser&lt;br /&gt;
+03. The Wombats - Give Me A Try (Don Diablo Remix)&lt;br /&gt;
+04. Smash of the Week: Tiesto &amp;amp; DallasK - Show Me&lt;br /&gt;
+05. Ephwurd &amp;amp; Mauz - Rock The Party&lt;br /&gt;
+06. David Solano - Take Me Away&lt;br /&gt;
+07. Carl Tricks - Quack&lt;br /&gt;
+08. Above &amp;amp; Beyond ft. Zoe Johnston - Peace Of Mind (Myon &amp;amp; Shane 54 Summer Of Love Mix)&lt;br /&gt;
+09. Third Party - Alive&lt;br /&gt;
+10. Dillon Francis &amp;amp; Dj Snake Get Low (W&amp;amp;W Remix)&lt;br /&gt;
+11. Orjan Nilsen - Now We’re Talking&lt;br /&gt;
+12. Borgoeus ft. Lights - Zero Gravity&lt;br /&gt;
+13. Dyro - Pure Noise&lt;br /&gt;
+14. Zedd &amp;amp; Botnek - Bumble Bee&lt;br /&gt;
+15. Five Knives - Savages (Tom Swoon Club Mix)&lt;br /&gt;
+16. Capa - From Here&lt;br /&gt;
+17. MaRlo - Atlantis&lt;br /&gt;
+18. W&amp;amp;W - Rave After Rave (Bosiyaw Remix)&lt;/p&gt;&lt;p&gt;&lt;a href="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-30-50305.m4a"&gt;File Download (56:17 min / 61 MB)&lt;/a&gt;&lt;/p&gt;</description>
+
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-30-50305.m4a" length="63963136" type="application/octet-stream" />
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-30-50305.m4a" length="63963136" type="application/octet-stream" />
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-30-50305.m4a" length="63963136" type="application/octet-stream" />
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-30-50305.m4a" length="63963136" type="application/octet-stream" />
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-30-50305.m4a" length="63963136" type="application/octet-stream" />
+    <itunes:duration>00:56:17</itunes:duration>
+</item>
+
+
+
+<item>
+    <pubDate>Sun, 24 May 2015 11:12:00 +0000</pubDate>
+    <title>W&amp;W - Mainstage 258 Podcast</title>
+    <link>http://podcast.wandwmusic.nl/index.php?id=223</link>
+    <guid>http://podcast.wandwmusic.nl/index.php?id=223</guid>
+    <dc:creator>W&amp;W Music</dc:creator>
+    <itunes:author>W&amp;W Music</itunes:author>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:keywords>Music</itunes:keywords>
+    <category>Music</category>
+    <itunes:subtitle>01. Dimitri Vegas &amp; Like Mike vs Ummet Ozcan - The Hum (Lost Frequencies Remix)
+02. MakJ &amp; Thomas Newson - Black
+03. Dash Berlin feat. Emma Hewitt - Waiting (Dash Berlin Miami 2015 Remix)
+04. Tom Swoon &amp; Kerano Feat. Cimo Fränkel - Here I </itunes:subtitle>
+    <itunes:summary>01. Dimitri Vegas &amp; Like Mike vs Ummet Ozcan - The Hum (Lost Frequencies Remix)
+02. MakJ &amp; Thomas Newson - Black
+03. Dash Berlin feat. Emma Hewitt - Waiting (Dash Berlin Miami 2015 Remix)
+04. Tom Swoon &amp; Kerano Feat. Cimo Fränkel - Here I Stand
+05. Mainstage ID:  ID - Wake Up
+06. Gregor Salto &amp; Wiwek - Miami
+07. Suyano &amp; Reeze - Switch Up
+08. Sandro Silva  Firestarter
+09. ID - Hold Me Close
+10. Syn Cole - May
+11. Wiz Khalifa Ft. Charlie Puth - See You Again (Shaan Edit)
+12. Shapov vs Amersy - Vavilon
+13. Smash of the Week: Carnage &amp; Timmy Trumpet &amp; KSHMR - Toca
+14. Tony Junior &amp; Dropgun - Cobra
+15. Marco V - We Will Be
+16. Rafael Frost &amp; Maria Nayler - No Mistakes
+17. TAI &amp; Scott Storch - Brick Wall
+18. Bass Modulators - Oxygen</itunes:summary>
+
+    <description>&lt;p&gt;01. Dimitri Vegas &amp;amp; Like Mike vs Ummet Ozcan - The Hum (Lost Frequencies Remix)&lt;br /&gt;
+02. MakJ &amp;amp; Thomas Newson - Black&lt;br /&gt;
+03. Dash Berlin feat. Emma Hewitt - Waiting (Dash Berlin Miami 2015 Remix)&lt;br /&gt;
+04. Tom Swoon &amp;amp; Kerano Feat. Cimo Fränkel - Here I Stand&lt;br /&gt;
+05. Mainstage ID:  ID - Wake Up&lt;br /&gt;
+06. Gregor Salto &amp;amp; Wiwek - Miami&lt;br /&gt;
+07. Suyano &amp;amp; Reeze - Switch Up&lt;br /&gt;
+08. Sandro Silva  Firestarter&lt;br /&gt;
+09. ID - Hold Me Close&lt;br /&gt;
+10. Syn Cole - May&lt;br /&gt;
+11. Wiz Khalifa Ft. Charlie Puth - See You Again (Shaan Edit)&lt;br /&gt;
+12. Shapov vs Amersy - Vavilon&lt;br /&gt;
+13. Smash of the Week: Carnage &amp;amp; Timmy Trumpet &amp;amp; KSHMR - Toca&lt;br /&gt;
+14. Tony Junior &amp;amp; Dropgun - Cobra&lt;br /&gt;
+15. Marco V - We Will Be&lt;br /&gt;
+16. Rafael Frost &amp;amp; Maria Nayler - No Mistakes&lt;br /&gt;
+17. TAI &amp;amp; Scott Storch - Brick Wall&lt;br /&gt;
+18. Bass Modulators - Oxygen&lt;/p&gt;&lt;p&gt;&lt;a href="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-24-50344.m4a"&gt;File Download (59:54 min / 65 MB)&lt;/a&gt;&lt;/p&gt;</description>
+
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-24-50344.m4a" length="68157440" type="application/octet-stream" />
+    <itunes:duration>00:59:54</itunes:duration>
+</item>
+
+
+
+<item>
+    <pubDate>Sat, 16 May 2015 16:18:00 +0000</pubDate>
+    <title>W&amp;W - Mainstage 257 Podcast</title>
+    <link>http://podcast.wandwmusic.nl/index.php?id=222</link>
+    <guid>http://podcast.wandwmusic.nl/index.php?id=222</guid>
+    <dc:creator>W&amp;W Music</dc:creator>
+    <itunes:author>W&amp;W Music</itunes:author>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:keywords>Music</itunes:keywords>
+    <category>Music</category>
+    <itunes:subtitle>01. 3Lau &amp; Nom De Strip ft. Estelle - The Night (Hunter Siegel Bootleg)
+02. Showtek ft. Vassy - Satisfied
+03. Axwell / Ingrosso - On My Way (Dave Winnel Remix)
+04. Rihanna - Bitch Better Have My Money (R3hab Remix)
+05. KSHMR - JAMMU
+06. Smash of the </itunes:subtitle>
+    <itunes:summary>01. 3Lau &amp; Nom De Strip ft. Estelle - The Night (Hunter Siegel Bootleg)
+02. Showtek ft. Vassy - Satisfied
+03. Axwell / Ingrosso - On My Way (Dave Winnel Remix)
+04. Rihanna - Bitch Better Have My Money (R3hab Remix)
+05. KSHMR - JAMMU
+06. Smash of the Week: Armin van Buuren ft. Mr Probz - Another You (Headhunterz Remix)
+07. Arno Cost &amp; Norman Doray ft. Mike Taylor - Rising Love
+08. Luke Bond &amp; Omnia - Reflex
+09. Jochen Miller - Atomic
+10. Gabriel &amp; Castellon - Shut Your Eyes (Zonderling Remix)
+11. Thomas Gold, Harrison &amp; HIIO - Take Me Home
+12. Mainstage ID: ID - Aftermath
+13. Dave Till &amp; Regi ft Rudy Zensky - HIYA
+14. Gareth Emery - Kings &amp; Queens
+15. David Solano - Take Me Away
+16. Andrew Rayel ft. Johnny Rose - Daylight
+17. Zaxx vs Riggi &amp; Piros - Alpha
+18. Sied van Riel &amp; Radion6 - Warpdrive</itunes:summary>
+
+    <description>&lt;p&gt;01. 3Lau &amp;amp; Nom De Strip ft. Estelle - The Night (Hunter Siegel Bootleg)&lt;br /&gt;
+02. Showtek ft. Vassy - Satisfied&lt;br /&gt;
+03. Axwell / Ingrosso - On My Way (Dave Winnel Remix)&lt;br /&gt;
+04. Rihanna - Bitch Better Have My Money (R3hab Remix)&lt;br /&gt;
+05. KSHMR - JAMMU&lt;br /&gt;
+06. Smash of the Week: Armin van Buuren ft. Mr Probz - Another You (Headhunterz Remix)&lt;br /&gt;
+07. Arno Cost &amp;amp; Norman Doray ft. Mike Taylor - Rising Love&lt;br /&gt;
+08. Luke Bond &amp;amp; Omnia - Reflex&lt;br /&gt;
+09. Jochen Miller - Atomic&lt;br /&gt;
+10. Gabriel &amp;amp; Castellon - Shut Your Eyes (Zonderling Remix)&lt;br /&gt;
+11. Thomas Gold, Harrison &amp;amp; HIIO - Take Me Home&lt;br /&gt;
+12. Mainstage ID: ID - Aftermath&lt;br /&gt;
+13. Dave Till &amp;amp; Regi ft Rudy Zensky - HIYA&lt;br /&gt;
+14. Gareth Emery - Kings &amp;amp; Queens&lt;br /&gt;
+15. David Solano - Take Me Away&lt;br /&gt;
+16. Andrew Rayel ft. Johnny Rose - Daylight&lt;br /&gt;
+17. Zaxx vs Riggi &amp;amp; Piros - Alpha&lt;br /&gt;
+18. Sied van Riel &amp;amp; Radion6 - Warpdrive&lt;/p&gt;&lt;p&gt;&lt;a href="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-16-68705.m4a"&gt;File Download (58:52 min / 64 MB)&lt;/a&gt;&lt;/p&gt;</description>
+
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-16-68705.m4a" length="67108864" type="application/octet-stream" />
+    <itunes:duration>00:58:52</itunes:duration>
+</item>
+
+
+
+<item>
+    <pubDate>Sun, 10 May 2015 11:26:00 +0000</pubDate>
+    <title>W&amp;W - Mainstage 256 Podcast</title>
+    <link>http://podcast.wandwmusic.nl/index.php?id=221</link>
+    <guid>http://podcast.wandwmusic.nl/index.php?id=221</guid>
+    <dc:creator>W&amp;W Music</dc:creator>
+    <itunes:author>W&amp;W Music</itunes:author>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:keywords>Music</itunes:keywords>
+    <category>Music</category>
+    <itunes:subtitle>01. Sam Feldt - Show Me Love (Quintino Remix)
+02. Timmy Trumpet - Freaks (W&amp;W Bigroom Edit)
+03. Tritonal &amp; Cash Cash - Untouchable
+04. Mainstage ID: ID - FAWL
+05. Armin van Buuren ft. Mr Probz - Another You (Mark Sixma Remix)
+06. Julian Calor - </itunes:subtitle>
+    <itunes:summary>01. Sam Feldt - Show Me Love (Quintino Remix)
+02. Timmy Trumpet - Freaks (W&amp;W Bigroom Edit)
+03. Tritonal &amp; Cash Cash - Untouchable
+04. Mainstage ID: ID - FAWL
+05. Armin van Buuren ft. Mr Probz - Another You (Mark Sixma Remix)
+06. Julian Calor - Sleeping Androids
+07. Laurent - Once Upon a Time  
+08. Henry Fong x Quad City Djs - C’Mon’N Ride It Bootyleg
+09. M.E.G. &amp; N.E.R.A.K. - Concorde
+10. Suspect 44 - Just With You
+11. Smash of the Week: David Solano - Take Me Away
+12. MoTi - House of Now (Tiesto Edit)
+13. Lucky Date &amp; David Solano - The End (Lush &amp; Simon Remix)
+14. Jetfire ft. Authentix - Yalem 
+15. Nom De Strip - Aliens
+16. Arty feat. Ray Dalton - Stronger
+17. Wildstylez &amp; Audiotricz - Turn The Music Up
+18. Timmus - Still Alive</itunes:summary>
+
+    <description>&lt;p&gt;01. Sam Feldt - Show Me Love (Quintino Remix)&lt;br /&gt;
+02. Timmy Trumpet - Freaks (W&amp;amp;W Bigroom Edit)&lt;br /&gt;
+03. Tritonal &amp;amp; Cash Cash - Untouchable&lt;br /&gt;
+04. Mainstage ID: ID - FAWL&lt;br /&gt;
+05. Armin van Buuren ft. Mr Probz - Another You (Mark Sixma Remix)&lt;br /&gt;
+06. Julian Calor - Sleeping Androids&lt;br /&gt;
+07. Laurent - Once Upon a Time  &lt;br /&gt;
+08. Henry Fong x Quad City Djs - C’Mon’N Ride It Bootyleg&lt;br /&gt;
+09. M.E.G. &amp;amp; N.E.R.A.K. - Concorde&lt;br /&gt;
+10. Suspect 44 - Just With You&lt;br /&gt;
+11. Smash of the Week: David Solano - Take Me Away&lt;br /&gt;
+12. MoTi - House of Now (Tiesto Edit)&lt;br /&gt;
+13. Lucky Date &amp;amp; David Solano - The End (Lush &amp;amp; Simon Remix)&lt;br /&gt;
+14. Jetfire ft. Authentix - Yalem &lt;br /&gt;
+15. Nom De Strip - Aliens&lt;br /&gt;
+16. Arty feat. Ray Dalton - Stronger&lt;br /&gt;
+17. Wildstylez &amp;amp; Audiotricz - Turn The Music Up&lt;br /&gt;
+18. Timmus - Still Alive&lt;/p&gt;&lt;p&gt;&lt;a href="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-10-51263.m4a"&gt;File Download (60:10 min / 66 MB)&lt;/a&gt;&lt;/p&gt;</description>
+
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-10-51263.m4a" length="69206016" type="application/octet-stream" />
+    <itunes:duration>01:00:10</itunes:duration>
+</item>
+
+
+
+<item>
+    <pubDate>Sat, 02 May 2015 20:21:00 +0000</pubDate>
+    <title>W&amp;W - Mainstage 255 Podcast</title>
+    <link>http://podcast.wandwmusic.nl/index.php?id=220</link>
+    <guid>http://podcast.wandwmusic.nl/index.php?id=220</guid>
+    <dc:creator>W&amp;W Music</dc:creator>
+    <itunes:author>W&amp;W Music</itunes:author>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:keywords>Music</itunes:keywords>
+    <category>Music</category>
+    <itunes:subtitle>01. Cabriolet Paris - The Way It Is (DDei &amp; Estate Remix) 
+02. Zedd ft. Selena Gomez - I Want You To Know (W&amp;W Bootleg)
+03. Ummet Ozcan - Lose Control
+04. Twoloud - Higher Of The Ground (Lars Pager &amp; Derek Hake Remix)
+05. R3hab vs Skytech </itunes:subtitle>
+    <itunes:summary>01. Cabriolet Paris - The Way It Is (DDei &amp; Estate Remix) 
+02. Zedd ft. Selena Gomez - I Want You To Know (W&amp;W Bootleg)
+03. Ummet Ozcan - Lose Control
+04. Twoloud - Higher Of The Ground (Lars Pager &amp; Derek Hake Remix)
+05. R3hab vs Skytech &amp; Fafaq - Tiger
+06. Eric Prydz - Generate (Marcus Schossow Remix) 0
+07. Dannic - Fonk     
+08. Mainstage ID: ID - Red Roses  
+09. Riggi &amp; Piros - Love Me A Little
+10. Oiki - WHOA!
+11. Smash of the Week: Wildstylez &amp; Audiotricz - Turn The Music Up
+12. O.B - Acid &amp; Horns
+13. Blasterjaxx - Forever
+14. Magnificence &amp; Alec Maire ft. Brooke Forman - Heartbeat (Nicky Romero Edit)  
+15. David Tort &amp; Moska - Music Feeds My Soul
+16. M.I.K.E. Push - Starcraft
+17. Marcel Woods - Advanced (MaRlo Remix)
+18. DVBBS - Always</itunes:summary>
+
+    <description>&lt;p&gt;01. Cabriolet Paris - The Way It Is (DDei &amp;amp; Estate Remix) &lt;br /&gt;
+02. Zedd ft. Selena Gomez - I Want You To Know (W&amp;amp;W Bootleg)&lt;br /&gt;
+03. Ummet Ozcan - Lose Control&lt;br /&gt;
+04. Twoloud - Higher Of The Ground (Lars Pager &amp;amp; Derek Hake Remix)&lt;br /&gt;
+05. R3hab vs Skytech &amp;amp; Fafaq - Tiger&lt;br /&gt;
+06. Eric Prydz - Generate (Marcus Schossow Remix) 0&lt;br /&gt;
+07. Dannic - Fonk     &lt;br /&gt;
+08. Mainstage ID: ID - Red Roses  &lt;br /&gt;
+09. Riggi &amp;amp; Piros - Love Me A Little&lt;br /&gt;
+10. Oiki - WHOA!&lt;br /&gt;
+11. Smash of the Week: Wildstylez &amp;amp; Audiotricz - Turn The Music Up&lt;br /&gt;
+12. O.B - Acid &amp;amp; Horns&lt;br /&gt;
+13. Blasterjaxx - Forever&lt;br /&gt;
+14. Magnificence &amp;amp; Alec Maire ft. Brooke Forman - Heartbeat (Nicky Romero Edit)  &lt;br /&gt;
+15. David Tort &amp;amp; Moska - Music Feeds My Soul&lt;br /&gt;
+16. M.I.K.E. Push - Starcraft&lt;br /&gt;
+17. Marcel Woods - Advanced (MaRlo Remix)&lt;br /&gt;
+18. DVBBS - Always&lt;/p&gt;&lt;p&gt;&lt;a href="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-02-83301.m4a"&gt;File Download (58:47 min / 64 MB)&lt;/a&gt;&lt;/p&gt;</description>
+
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-05-02-83301.m4a" length="67108864" type="application/octet-stream" />
+    <itunes:duration>00:58:47</itunes:duration>
+</item>
+
+
+
+<item>
+    <pubDate>Mon, 27 Apr 2015 07:58:00 +0000</pubDate>
+    <title>W&amp;W - Mainstage 254 Podcast</title>
+    <link>http://podcast.wandwmusic.nl/index.php?id=218</link>
+    <guid>http://podcast.wandwmusic.nl/index.php?id=218</guid>
+    <dc:creator>W&amp;W Music</dc:creator>
+    <itunes:author>W&amp;W Music</itunes:author>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:keywords>Music</itunes:keywords>
+    <category>Music</category>
+    <itunes:subtitle>01. Don Diablo ft. Emeni - Universe
+02. Armin van Buuren feat. Mr. Probz - Another You
+03. Merk &amp; Kremont - Get Get Down
+04. Mauro Picotto - Komodo (Save A Soul) (John Dish Remix)
+05. Bassjackers &amp; Brooks - Alamo
+06. Galantis - Peanut Butter </itunes:subtitle>
+    <itunes:summary>01. Don Diablo ft. Emeni - Universe
+02. Armin van Buuren feat. Mr. Probz - Another You
+03. Merk &amp; Kremont - Get Get Down
+04. Mauro Picotto - Komodo (Save A Soul) (John Dish Remix)
+05. Bassjackers &amp; Brooks - Alamo
+06. Galantis - Peanut Butter Jelly
+07. Paris Blohm &amp; Steerner feat. Paul Aiden - Fight Forever
+08. Michael Brun &amp; Dirty Twist - Woo
+09. Dzeko &amp; Torres ft. Delaney - Air 
+10. Julian Jordan - Blinded By Light
+11. Jetfire ft. Authentix - Yalem
+12. Above &amp; Beyond ft. Zoe Johnston - Peace Of Mind
+13. Borgore &amp; Addison - School Daze
+14. Antillas &amp; Dankann vs Tellur - Traction
+15. Carl Nunes &amp; Jenaux feat. Ruby Prophet - Killer
+16. Venom One &amp; Tomas Heredia - Moments
+17. Smash of the Week: Headhunterz &amp; Crystal Lake - Live Your Life
+18. Blasterjaxx &amp; DBSTF feat. Ryder - Beautiful World (D-Block &amp; S-te-Fan Remix)</itunes:summary>
+
+    <description>&lt;p&gt;01. Don Diablo ft. Emeni - Universe&lt;br /&gt;
+02. Armin van Buuren feat. Mr. Probz - Another You&lt;br /&gt;
+03. Merk &amp;amp; Kremont - Get Get Down&lt;br /&gt;
+04. Mauro Picotto - Komodo (Save A Soul) (John Dish Remix)&lt;br /&gt;
+05. Bassjackers &amp;amp; Brooks - Alamo&lt;br /&gt;
+06. Galantis - Peanut Butter Jelly&lt;br /&gt;
+07. Paris Blohm &amp;amp; Steerner feat. Paul Aiden - Fight Forever&lt;br /&gt;
+08. Michael Brun &amp;amp; Dirty Twist - Woo&lt;br /&gt;
+09. Dzeko &amp;amp; Torres ft. Delaney - Air &lt;br /&gt;
+10. Julian Jordan - Blinded By Light&lt;br /&gt;
+11. Jetfire ft. Authentix - Yalem&lt;br /&gt;
+12. Above &amp;amp; Beyond ft. Zoe Johnston - Peace Of Mind&lt;br /&gt;
+13. Borgore &amp;amp; Addison - School Daze&lt;br /&gt;
+14. Antillas &amp;amp; Dankann vs Tellur - Traction&lt;br /&gt;
+15. Carl Nunes &amp;amp; Jenaux feat. Ruby Prophet - Killer&lt;br /&gt;
+16. Venom One &amp;amp; Tomas Heredia - Moments&lt;br /&gt;
+17. Smash of the Week: Headhunterz &amp;amp; Crystal Lake - Live Your Life&lt;br /&gt;
+18. Blasterjaxx &amp;amp; DBSTF feat. Ryder - Beautiful World (D-Block &amp;amp; S-te-Fan Remix)&lt;/p&gt;&lt;p&gt;&lt;a href="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-04-27-38734.m4a"&gt;File Download (59:24 min / 65 MB)&lt;/a&gt;&lt;/p&gt;</description>
+
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-04-27-38734.m4a" length="68157440" type="application/octet-stream" />
+    <itunes:duration>00:59:24</itunes:duration>
+</item>
+
+
+
+<item>
+    <pubDate>Sat, 18 Apr 2015 18:21:00 +0000</pubDate>
+    <title>W&amp;W - Mainstage 253 Podcast</title>
+    <link>http://podcast.wandwmusic.nl/index.php?id=217</link>
+    <guid>http://podcast.wandwmusic.nl/index.php?id=217</guid>
+    <dc:creator>W&amp;W Music</dc:creator>
+    <itunes:author>W&amp;W Music</itunes:author>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:keywords>Music</itunes:keywords>
+    <category>Music</category>
+    <itunes:subtitle>01. Eric Prydz - Generate
+02. Vicetone ft. Kat Nestel - Angels
+03. Smash of the Week:  Twoloud - Move (Showtek Edit)
+04. Arcando - Canyon  [Free Download] 
+05. Oliver Heldens - Bunny Dance
+06. Sander van Doorn - Orli Tali Ma
+07. FTampa - That Drop 
+08. </itunes:subtitle>
+    <itunes:summary>01. Eric Prydz - Generate
+02. Vicetone ft. Kat Nestel - Angels
+03. Smash of the Week:  Twoloud - Move (Showtek Edit)
+04. Arcando - Canyon  [Free Download] 
+05. Oliver Heldens - Bunny Dance
+06. Sander van Doorn - Orli Tali Ma
+07. FTampa - That Drop 
+08. Maurice West - Medusa
+09. Tritonal &amp; Juventa ft. Micky Blue - Lost
+10. Firebeatz &amp; DubVision ft Ruby Prophet  - Invincible
+11. Dimaro - Summer
+12. Tom Staar - Bora
+13. Tom Fall - Bringing It Back
+14. Eva Shaw - Moxie
+15. Jordy Dazz - Disco Nights 
+16. Lost Frequencies - Are You With Me (Dash Berlin Remix)  
+17. Andrew Bayer - Do Androids Dream Part 2
+18. Steve Aoki ft. Fall Out Boy - Back To Earth (The Chainsmokers Remix)</itunes:summary>
+
+    <description>&lt;p&gt;01. Eric Prydz - Generate&lt;br /&gt;
+02. Vicetone ft. Kat Nestel - Angels&lt;br /&gt;
+03. Smash of the Week:  Twoloud - Move (Showtek Edit)&lt;br /&gt;
+04. Arcando - Canyon  [Free Download] &lt;br /&gt;
+05. Oliver Heldens - Bunny Dance&lt;br /&gt;
+06. Sander van Doorn - Orli Tali Ma&lt;br /&gt;
+07. FTampa - That Drop &lt;br /&gt;
+08. Maurice West - Medusa&lt;br /&gt;
+09. Tritonal &amp;amp; Juventa ft. Micky Blue - Lost&lt;br /&gt;
+10. Firebeatz &amp;amp; DubVision ft Ruby Prophet  - Invincible&lt;br /&gt;
+11. Dimaro - Summer&lt;br /&gt;
+12. Tom Staar - Bora&lt;br /&gt;
+13. Tom Fall - Bringing It Back&lt;br /&gt;
+14. Eva Shaw - Moxie&lt;br /&gt;
+15. Jordy Dazz - Disco Nights &lt;br /&gt;
+16. Lost Frequencies - Are You With Me (Dash Berlin Remix)  &lt;br /&gt;
+17. Andrew Bayer - Do Androids Dream Part 2&lt;br /&gt;
+18. Steve Aoki ft. Fall Out Boy - Back To Earth (The Chainsmokers Remix)&lt;/p&gt;&lt;p&gt;&lt;a href="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-04-18-76095.m4a"&gt;File Download (58:28 min / 64 MB)&lt;/a&gt;&lt;/p&gt;</description>
+
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-04-18-76095.m4a" length="67108864" type="application/octet-stream" />
+    <itunes:duration>00:58:28</itunes:duration>
+</item>
+
+
+
+<item>
+    <pubDate>Mon, 13 Apr 2015 07:04:00 +0000</pubDate>
+    <title>W&amp;W - Mainstage 252 Podcast</title>
+    <link>http://podcast.wandwmusic.nl/index.php?id=216</link>
+    <guid>http://podcast.wandwmusic.nl/index.php?id=216</guid>
+    <dc:creator>W&amp;W Music</dc:creator>
+    <itunes:author>W&amp;W Music</itunes:author>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:keywords>Music</itunes:keywords>
+    <category>Music</category>
+    <itunes:subtitle>01. Martin Garrix &amp; Tiesto - The Only Way Is Up
+02. LTric - This Feeling (Kryder Remix)
+03. Alesso feat. Roy English - Cool (Bottai Remix)
+04. Burns - When Im Around U
+05. DVBBS - White Clouds
+06. A-Trak ft. Cory Enemy &amp; Nico Stadi - Ibanez </itunes:subtitle>
+    <itunes:summary>01. Martin Garrix &amp; Tiesto - The Only Way Is Up
+02. LTric - This Feeling (Kryder Remix)
+03. Alesso feat. Roy English - Cool (Bottai Remix)
+04. Burns - When Im Around U
+05. DVBBS - White Clouds
+06. A-Trak ft. Cory Enemy &amp; Nico Stadi - Ibanez (Arena Version)
+07. MOTi vs Lost Frequencies - Valencia Are You With Me (W&amp;W Ultra Mashup)
+08. Nicky Romero &amp; Volt &amp; State - Warriors
+09. Husman - XV
+10. Holl &amp; Rush - Sonar
+11. Axwell &amp; Ingrosso ft. Salem El Fakir - On My Way
+12. Smash of the Week: Dimitri Vegas &amp; Like Mike vs Ummet Ozcan - The Hum
+13. Dustin Lenji - Gladiator
+14. Dimitri Vangelis &amp; Wyman - Zonk
+15. Codeko - Trace 
+16. Vida - Arctic Lights
+17. Chris Schweizer - Era
+18. Alex Gaudino &amp; Manufactured Superstars feat. Zak Waters - Lights Go Out</itunes:summary>
+
+    <description>&lt;p&gt;01. Martin Garrix &amp;amp; Tiesto - The Only Way Is Up&lt;br /&gt;
+02. LTric - This Feeling (Kryder Remix)&lt;br /&gt;
+03. Alesso feat. Roy English - Cool (Bottai Remix)&lt;br /&gt;
+04. Burns - When Im Around U&lt;br /&gt;
+05. DVBBS - White Clouds&lt;br /&gt;
+06. A-Trak ft. Cory Enemy &amp;amp; Nico Stadi - Ibanez (Arena Version)&lt;br /&gt;
+07. MOTi vs Lost Frequencies - Valencia Are You With Me (W&amp;amp;W Ultra Mashup)&lt;br /&gt;
+08. Nicky Romero &amp;amp; Volt &amp;amp; State - Warriors&lt;br /&gt;
+09. Husman - XV&lt;br /&gt;
+10. Holl &amp;amp; Rush - Sonar&lt;br /&gt;
+11. Axwell &amp;amp; Ingrosso ft. Salem El Fakir - On My Way&lt;br /&gt;
+12. Smash of the Week: Dimitri Vegas &amp;amp; Like Mike vs Ummet Ozcan - The Hum&lt;br /&gt;
+13. Dustin Lenji - Gladiator&lt;br /&gt;
+14. Dimitri Vangelis &amp;amp; Wyman - Zonk&lt;br /&gt;
+15. Codeko - Trace &lt;br /&gt;
+16. Vida - Arctic Lights&lt;br /&gt;
+17. Chris Schweizer - Era&lt;br /&gt;
+18. Alex Gaudino &amp;amp; Manufactured Superstars feat. Zak Waters - Lights Go Out&lt;/p&gt;&lt;p&gt;&lt;a href="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-04-13-35480.m4a"&gt;File Download (56:55 min / 62 MB)&lt;/a&gt;&lt;/p&gt;</description>
+
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-04-13-35480.m4a" length="65011712" type="application/octet-stream" />
+    <itunes:duration>00:56:55</itunes:duration>
+</item>
+
+
+
+<item>
+    <pubDate>Tue, 07 Apr 2015 14:51:00 +0000</pubDate>
+    <title>W&amp;W - Mainstage 251 Podcast</title>
+    <link>http://podcast.wandwmusic.nl/index.php?id=215</link>
+    <guid>http://podcast.wandwmusic.nl/index.php?id=215</guid>
+    <dc:creator>W&amp;W Music</dc:creator>
+    <itunes:author>W&amp;W Music</itunes:author>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:keywords>Music</itunes:keywords>
+    <category>Music</category>
+    <itunes:subtitle>W&amp;W Live at Ultra Music Festival Miami 2015 (Mainstage)</itunes:subtitle>
+    <itunes:summary>W&amp;W Live at Ultra Music Festival Miami 2015 (Mainstage)</itunes:summary>
+
+    <description>&lt;p&gt;W&amp;amp;W Live at Ultra Music Festival Miami 2015 (Mainstage)&lt;/p&gt;&lt;p&gt;&lt;a href="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-04-07-64696.mp3"&gt;File Download (57:57 min / 133 MB)&lt;/a&gt;&lt;/p&gt;</description>
+
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-04-07-64696.mp3" length="139460608" type="audio/mpeg" />
+    <itunes:duration>00:57:57</itunes:duration>
+</item>
+
+
+
+<item>
+    <pubDate>Sun, 29 Mar 2015 11:26:00 +0000</pubDate>
+    <title>W&amp;W - Mainstage 250 Podcast</title>
+    <link>http://podcast.wandwmusic.nl/index.php?id=214</link>
+    <guid>http://podcast.wandwmusic.nl/index.php?id=214</guid>
+    <dc:creator>W&amp;W Music</dc:creator>
+    <itunes:author>W&amp;W Music</itunes:author>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:keywords>Music</itunes:keywords>
+    <category>Music</category>
+    <itunes:subtitle>01. Martin Garrix ft. Usher - Dont Look Down
+02. Pep &amp; Rash - Rumors (Deniz Koyu Remix)
+03. Michael Woods - Slice Of Life
+04. Mainstage ID: ID - ID
+05. Jochen Miller ft. Hansen Tomas - A Million Pieces
+06. Bassjackers &amp; Afrojack - What We </itunes:subtitle>
+    <itunes:summary>01. Martin Garrix ft. Usher - Dont Look Down
+02. Pep &amp; Rash - Rumors (Deniz Koyu Remix)
+03. Michael Woods - Slice Of Life
+04. Mainstage ID: ID - ID
+05. Jochen Miller ft. Hansen Tomas - A Million Pieces
+06. Bassjackers &amp; Afrojack - What We Live
+07. Sick Individuals ft. Kaelyn Behr - Never Fade
+08. TJR - How Ya Feelin
+09. Felix - Dont You Want Me (Dimitri Vegas &amp; Like Mike Remix)
+10. W&amp;W - Rave After Rave
+11. Toby Green - Void
+12. Enzo Darren feat. Delaney Jane - Adonis
+13. Danny Avila - Plastik
+14. Orjan Nilsen - The Edge
+15. Dyro - Foxtrot
+16. Borgeous &amp; David Solano - Big Bang (2015 Life In Color Anthem)
+17. Talemono - Overload
+18. Nero - The Thrill</itunes:summary>
+
+    <description>&lt;p&gt;01. Martin Garrix ft. Usher - Dont Look Down&lt;br /&gt;
+02. Pep &amp;amp; Rash - Rumors (Deniz Koyu Remix)&lt;br /&gt;
+03. Michael Woods - Slice Of Life&lt;br /&gt;
+04. Mainstage ID: ID - ID&lt;br /&gt;
+05. Jochen Miller ft. Hansen Tomas - A Million Pieces&lt;br /&gt;
+06. Bassjackers &amp;amp; Afrojack - What We Live&lt;br /&gt;
+07. Sick Individuals ft. Kaelyn Behr - Never Fade&lt;br /&gt;
+08. TJR - How Ya Feelin&lt;br /&gt;
+09. Felix - Dont You Want Me (Dimitri Vegas &amp;amp; Like Mike Remix)&lt;br /&gt;
+10. W&amp;amp;W - Rave After Rave&lt;br /&gt;
+11. Toby Green - Void&lt;br /&gt;
+12. Enzo Darren feat. Delaney Jane - Adonis&lt;br /&gt;
+13. Danny Avila - Plastik&lt;br /&gt;
+14. Orjan Nilsen - The Edge&lt;br /&gt;
+15. Dyro - Foxtrot&lt;br /&gt;
+16. Borgeous &amp;amp; David Solano - Big Bang (2015 Life In Color Anthem)&lt;br /&gt;
+17. Talemono - Overload&lt;br /&gt;
+18. Nero - The Thrill&lt;/p&gt;&lt;p&gt;&lt;a href="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-03-29-52020.m4a"&gt;File Download (56:21 min / 62 MB)&lt;/a&gt;&lt;/p&gt;</description>
+
+    <enclosure url="http://podcast.wandwmusic.nl/pod/wandw_mainstage_podcast-2015-03-29-52020.m4a" length="65011712" type="application/octet-stream" />
+    <itunes:duration>00:56:21</itunes:duration>
+</item>
+
+
+
+</channel>
+
+</rss>


### PR DESCRIPTION
*(Also added a test RSS file to ensure it passes the test)*


Although it is not common to have multiple Enclosures per Item according to
[RSSBoard](http://www.rssboard.org/rss-profile#element-channel-item-enclosure)

I ran into this issue with a Podcast RSS parsing, and created a fix to allow it in case it occurs