### PR TITLE
Update dependency paths

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/suapapa/go-charset/charset"
-	_ "github.com/suapapa/go-charset/data" //initialize only
+	"github.com/paulrosania/go-charset/charset"
+	_ "github.com/paulrosania/go-charset/data" //initialize only
 )
 
 const (


### PR DESCRIPTION
The repo for https://github.com/suapapa/go-charset seems to be gone. Updated it with the top hit on Google, https://github.com/paulrosania/go-charset, which seems to work out.