### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -94,7 +94,7 @@ func Read(url string) (*Channel, error) {
 	return ReadWithClient(url, http.DefaultClient)
 }
 
-//Read without certificate check
+//InsecureRead reads without certificate check
 func InsecureRead(url string) (*Channel, error) {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?